### PR TITLE
add `Global mode` and `Tee broken mode`

### DIFF
--- a/service/src/main/java/io/github/a13e300/tricky_store/Config.kt
+++ b/service/src/main/java/io/github/a13e300/tricky_store/Config.kt
@@ -9,14 +9,23 @@ import java.io.File
 object Config {
     private val hackPackages = mutableSetOf<String>()
     private val generatePackages = mutableSetOf<String>()
+    private var isGlobalMode = false
+    private var isTeeBrokenMode = false
 
     private fun updateTargetPackages(f: File?) = runCatching {
+        if (isGlobalMode) {
+            Logger.i("Global mode is enabled, skipping updateTargetPackages execution.")
+            return@runCatching
+        }
         hackPackages.clear()
         generatePackages.clear()
         f?.readLines()?.forEach {
             if (it.isNotBlank() && !it.startsWith("#")) {
                 val n = it.trim()
-                if (n.endsWith("!")) generatePackages.add(n.removeSuffix("!").trim())
+                if (isTeeBrokenMode || n.endsWith("!"))
+                    generatePackages.add(
+                        n.removeSuffix("!").trim()
+                    )
                 else hackPackages.add(n)
             }
         }
@@ -31,9 +40,21 @@ object Config {
         Logger.e("failed to update keybox", it)
     }
 
+    private fun updateGlobalMode(f: File?) {
+        isGlobalMode = f?.exists() == true
+        Logger.i("Global mode is ${if (isGlobalMode) "enabled" else "disabled"}")
+    }
+
+    private fun updateTeeBrokenMode(f: File?) {
+        isTeeBrokenMode = f?.exists() == true
+        Logger.i("TEE broken mode is ${if (isTeeBrokenMode) "enabled" else "disabled"}")
+    }
+
     private const val CONFIG_PATH = "/data/adb/tricky_store"
     private const val TARGET_FILE = "target.txt"
     private const val KEYBOX_FILE = "keybox.xml"
+    private const val GLOBAL_MODE_FILE = "global_mode"
+    private const val TEE_BROKEN_MODE_FILE = "tee_broken_mode"
     private val root = File(CONFIG_PATH)
 
     object ConfigObserver : FileObserver(root, CLOSE_WRITE or DELETE or MOVED_FROM or MOVED_TO) {
@@ -47,17 +68,30 @@ object Config {
             when (path) {
                 TARGET_FILE -> updateTargetPackages(f)
                 KEYBOX_FILE -> updateKeyBox(f)
+                GLOBAL_MODE_FILE -> {
+                    updateGlobalMode(f)
+                    updateTargetPackages(File(root, TARGET_FILE))
+                }
+
+                TEE_BROKEN_MODE_FILE -> {
+                    updateTeeBrokenMode(f)
+                    updateTargetPackages(File(root, TARGET_FILE))
+                }
             }
         }
     }
 
     fun initialize() {
         root.mkdirs()
-        val scope = File(root, TARGET_FILE)
-        if (scope.exists()) {
-            updateTargetPackages(scope)
-        } else {
-            Logger.e("target.txt file not found, please put it to $scope !")
+        updateGlobalMode(File(root, GLOBAL_MODE_FILE))
+        updateTeeBrokenMode(File(root, TEE_BROKEN_MODE_FILE))
+        if (!isGlobalMode) {
+            val scope = File(root, TARGET_FILE)
+            if (scope.exists()) {
+                updateTargetPackages(scope)
+            } else {
+                Logger.e("target.txt file not found, please put it to $scope !")
+            }
         }
         val keybox = File(root, KEYBOX_FILE)
         if (!keybox.exists()) {
@@ -77,15 +111,14 @@ object Config {
         return iPm
     }
 
-    fun needHack(callingUid: Int) = kotlin.runCatching {
-        if (hackPackages.isEmpty()) return false
+    private fun checkPackages(packages: Set<String>, callingUid: Int) = kotlin.runCatching {
+        if (isGlobalMode) return true
+        if (packages.isEmpty()) return false
         val ps = getPm()?.getPackagesForUid(callingUid)
-        ps?.any { it in hackPackages }
+        ps?.any { it in packages }
     }.onFailure { Logger.e("failed to get packages", it) }.getOrNull() ?: false
 
-    fun needGenerate(callingUid: Int) = kotlin.runCatching {
-        if (generatePackages.isEmpty()) return false
-        val ps = getPm()?.getPackagesForUid(callingUid)
-        ps?.any { it in generatePackages }
-    }.onFailure { Logger.e("failed to get packages", it) }.getOrNull() ?: false
+    fun needHack(callingUid: Int): Boolean = checkPackages(hackPackages, callingUid)
+
+    fun needGenerate(callingUid: Int): Boolean = checkPackages(generatePackages, callingUid)
 }


### PR DESCRIPTION
- `Global mode`: If the `global_mode` file exists in the `/data/adb/tricky_store` directory, the application will be effective for all apps without needing to create the target.txt file.
- `Tee broken mode`: If the `tee_broken_mode` file exists in the `/data/adb/tricky_store` directory, all package names in the `target.txt` file will be added to generatePackages, regardless of whether the package name ends with `!`.

For users with TEE broken devices, if `Global mode` is enabled, `Tee broken mode` must also be enabled for proper operation.